### PR TITLE
Error and limit handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,3 @@ When you block a list creator, you are automatically removed from the list. This
 ## Notes
 
 * This is an extremely simple script, made in half an hour to [give a little help](https://twitter.com/moorehn/status/1089185034727313408). All contributions are welcome via complete, and documented, pull request.
-* Twitter has an API rate limit. If/when you hit the rate limit, the script will end abruptly with an error message. Since you can just restart the script manually every 15 minutes (= the timing that Twitter uses for rate limiting), no error handling or retrying was added.

--- a/scripts.py
+++ b/scripts.py
@@ -1,0 +1,23 @@
+def error_handler(error):
+    """Log a TweepError exception."""
+    if error.api_code:
+        if error.api_code == 32:
+            print("invalid API authentication tokens")
+        elif error.api_code == 34:
+            print("requested object (user, Tweet, etc) not found")
+        elif error.api_code == 64:
+            print("your account is suspended and is not permitted")
+        elif error.api_code == 130:
+            print("Twitter is currently in over capacity")
+        elif error.api_code == 131:
+            print("internal Twitter error occurred")
+        elif error.api_code == 135:
+            print("could not authenticate your API tokens")
+        elif error.api_code == 136:
+            print("you have been blocked to perform this action")
+        elif error.api_code == 179:
+            print("you are not authorized to see this Tweet")
+        else:
+            print("error while using the REST API: %s", tweep_error)
+    else:
+        print("error with Twitter: %s", tweep_error)

--- a/start.py
+++ b/start.py
@@ -1,6 +1,7 @@
 import os
 import tweepy
 from dotenv import load_dotenv, find_dotenv
+from scripts import error_handler
 
 # Load environment settings.
 load_dotenv(find_dotenv())
@@ -14,12 +15,16 @@ ACCESS_TOKEN_SECRET = os.getenv('ACCESS_TOKEN_SECRET')
 auth = tweepy.OAuthHandler(CONSUMER_KEY, CONSUMER_SECRET)
 auth.set_access_token(ACCESS_TOKEN, ACCESS_TOKEN_SECRET)
 
-api = tweepy.API(auth)
+api = tweepy.API(auth, wait_on_rate_limit=True, wait_on_rate_limit_notify=True)
 
 # Fetch lists we've been added to.
 lists = api.lists_memberships()
 
 for entry in lists:
-    creator_screen_name = entry.user.screen_name
-    api.create_block(screen_name=creator_screen_name)
-    print('Blocked @{}, creator of "{}".'.format(creator_screen_name, entry.name))
+    try:
+        creator_screen_name = entry.user.screen_name
+        api.create_block(screen_name=creator_screen_name)
+        print('Blocked @{}, creator of "{}".'.format(creator_screen_name, entry.name))
+    except Exception as e:
+        # Return human readable error message on fail
+        error_handler(e.api_code)

--- a/start.py
+++ b/start.py
@@ -23,7 +23,7 @@ lists = api.lists_memberships()
 for entry in lists:
     try:
         creator_screen_name = entry.user.screen_name
-        api.create_block(screen_name=creator_screen_name)
+        api.create_block(creator_screen_name)
         print('Blocked @{}, creator of "{}".'.format(creator_screen_name, entry.name))
     except Exception as e:
         # Return human readable error message on fail


### PR DESCRIPTION
Hi,

I have added simple error handling to the script. I broke out the function for returning a human readable message in a separate script in order to keep the main _start.py_ clean from clutter.
It simply attempts to create the Tweepy block and if an error returns passes this to `error_handler`. This could be extended to incorporate more likely error messages.

Have extended the Tweepy defining of the API to incorporate the standard rate limit wait and notify.

Found that defining the `screen_name` parameter when calling create block stopped the script from working at all.

Thanks